### PR TITLE
[codex] Auto-label reported when Missive link is added

### DIFF
--- a/.github/workflows/auto-label-reported-from-missive.yml
+++ b/.github/workflows/auto-label-reported-from-missive.yml
@@ -1,0 +1,42 @@
+name: Auto-label reported from Missive
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add reported label when Missive conversation is linked
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const comment = context.payload.comment;
+
+            // `issue_comment` also fires for PRs; we only want issues.
+            if (issue.pull_request) {
+              return;
+            }
+
+            const body = comment.body || "";
+
+            // Match Missive conversation URLs like:
+            // https://mail.missiveapp.com/#inbox/conversations/<id>
+            const missiveConversationUrlRe =
+              /https?:\/\/[\S]*missiveapp\.com\/#[\S]*\bconversations\/[A-Za-z0-9-]+/i;
+
+            if (!missiveConversationUrlRe.test(body)) {
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: ["reported"],
+            });

--- a/.github/workflows/auto-label-reported-from-missive.yml
+++ b/.github/workflows/auto-label-reported-from-missive.yml
@@ -23,6 +23,15 @@ jobs:
               return;
             }
 
+            const alreadyReported = (issue.labels || []).some((label) => {
+              const name = typeof label?.name === "string" ? label.name : "";
+              return name.toLowerCase() === "reported";
+            });
+
+            if (alreadyReported) {
+              return;
+            }
+
             const body = comment.body || "";
 
             // Match Missive conversation URLs like:


### PR DESCRIPTION
## What / Why
Issues in this repo are often created automatically, but some are reported by users via email. We attach those emails in Missive, and Missive posts a comment containing a Missive conversation URL.

Today the `reported` label is applied manually. This PR adds automation so that when a Missive conversation link is present in an issue comment, the issue is labeled `reported` automatically.

## Behavior
- Triggers on issue comments when they are **created or edited**.
- If the comment body contains a Missive conversation URL (e.g. `https://mail.missiveapp.com/#inbox/conversations/<id>`), the workflow adds the `reported` label.
- The workflow **does not run for PR comments**.
- The workflow **no-ops if the issue already has the `reported` label**.

## Implementation
- Adds `.github/workflows/auto-label-reported-from-missive.yml` using `actions/github-script`.
- Uses minimal permissions: `issues: write`.

## Validation
- Reviewed existing open `reported` issues and confirmed Missive links follow patterns like:
  - `Missive conversation: https://mail.missiveapp.com/#inbox/conversations/<uuid>`
  - (variant) `https://mail.missiveapp.com/#sent/.../conversations/<uuid>/...`
  The workflow regex matches both because it looks for `missiveapp.com/#...conversations/<id>`.

No automated tests were added (repo is workflow-only).
