### PR TITLE
Document the repo and automate label upkeep

### DIFF
--- a/.github/scraper-labels.json
+++ b/.github/scraper-labels.json
@@ -1,0 +1,45 @@
+{
+  "_comment": "Mapping used by .github/scripts/label_from_project.py. See AGENTS.md.",
+
+  "_scraper_labels_comment": "morph.io slug -> the system label for authorities that scraper handles. Only multi-authority scrapers appear here: whether a bespoke single-authority scraper counts as `custom` is a judgement call, so those are deliberately left unmapped.",
+  "scraper_labels": {
+    "multiple_masterview": "masterview",
+    "multiple_greenlight": "greenlight",
+    "multiple_epathway_scraper": "epathway",
+    "multiple_icon": "icon",
+    "multiple_technology_one": "technology one",
+    "multiple_horizon": "horizon",
+    "multiple_civica": "civica",
+    "multiple_nsw_planning_lgas": "nsw planning portal",
+    "multiple_atdis": "ATDIS",
+    "multiple_developmenti": "development-i",
+    "multiple_cianywhere": "ci-anywhere",
+    "multiple_html_table": "html table",
+    "multiple_div_cards": "div_card",
+    "multiple_ePlanning": "ePlanning",
+    "master_planbuild": "planbuild (tas)"
+  },
+
+  "_system_labels_comment": "Every label that answers 'which system is this authority on'. If an issue already carries one of these, the scraper-derived label is skipped -- that is what protects authorities whose label has deliberately moved ahead of their Scraper (Morph) field.",
+  "system_labels": [
+    "masterview",
+    "greenlight",
+    "epathway",
+    "icon",
+    "technology one",
+    "horizon",
+    "civica",
+    "nsw planning portal",
+    "ATDIS",
+    "development-i",
+    "ci-anywhere",
+    "html table",
+    "div_card",
+    "ePlanning",
+    "planbuild (tas)",
+    "granicus",
+    "elementorg",
+    "DxP T1",
+    "custom"
+  ]
+}

--- a/.github/scripts/label_from_project.py
+++ b/.github/scripts/label_from_project.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Apply the labels that can be derived from the org project to open issues.
+
+Two rules, both strictly additive (see AGENTS.md):
+
+1. The system label implied by the item's `Scraper (Morph)` field, but only when the
+   issue carries no system label at all. An issue whose label already disagrees with its
+   scraper field is a migration in progress and must be left alone.
+2. `ready awaiting budget` when the item's `Status` is `Budget wait`.
+
+Candidates are then filtered against each issue's timeline: if a label has ever been
+removed from an issue, it is never re-applied. That check runs over candidates only, not
+over every project item.
+
+Nothing is ever removed. Standard library only -- no pip install on the runner.
+
+Usage: GH_TOKEN=... label_from_project.py [--dry-run]
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ORG = "planningalerts-scrapers"
+REPO = "planningalerts-scrapers/issues"
+PROJECT_NUMBER = 3
+BUDGET_STATUS = "Budget wait"
+BUDGET_LABEL = "ready awaiting budget"
+MORPH_PREFIX = "https://morph.io/planningalerts-scrapers/"
+
+CONFIG_PATH = Path(__file__).resolve().parent.parent / "scraper-labels.json"
+API = "https://api.github.com"
+
+PROJECT_QUERY = """
+query($org: String!, $number: Int!, $cursor: String) {
+  organization(login: $org) {
+    projectV2(number: $number) {
+      items(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          content {
+            __typename
+            ... on Issue {
+              number
+              state
+              repository { nameWithOwner }
+              labels(first: 50) { nodes { name } }
+            }
+          }
+          fieldValues(first: 30) {
+            nodes {
+              __typename
+              ... on ProjectV2ItemFieldTextValue {
+                text
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+REMOVED_LABELS_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      timelineItems(itemTypes: [UNLABELED_EVENT], first: 100) {
+        nodes { ... on UnlabeledEvent { label { name } } }
+      }
+    }
+  }
+}
+"""
+
+
+def request(url, token, data=None):
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(data).encode() if data is not None else None,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "planningalerts-scrapers-issue-labeller",
+        },
+    )
+    with urllib.request.urlopen(req) as response:
+        body = response.read()
+    return json.loads(body) if body else {}
+
+
+def graphql(token, query, **variables):
+    result = request(f"{API}/graphql", token, {"query": query, "variables": variables})
+    if "errors" in result:
+        raise RuntimeError(f"GraphQL error: {result['errors']}")
+    return result["data"]
+
+
+def project_items(token):
+    """Yield (issue_number, labels, fields) for every open issue in this repo."""
+    cursor = None
+    total = 0
+    while True:
+        page = graphql(token, PROJECT_QUERY, org=ORG, number=PROJECT_NUMBER, cursor=cursor)
+        items = page["organization"]["projectV2"]["items"]
+        for item in items["nodes"]:
+            total += 1
+            content = item["content"] or {}
+            if content.get("__typename") != "Issue":
+                continue
+            if content["state"] != "OPEN":
+                continue
+            if content["repository"]["nameWithOwner"] != REPO:
+                continue
+            fields = {}
+            for value in item["fieldValues"]["nodes"]:
+                name = (value.get("field") or {}).get("name")
+                if name:
+                    fields[name] = value.get("text") or value.get("name")
+            labels = {label["name"] for label in content["labels"]["nodes"]}
+            yield content["number"], labels, fields
+        if not items["pageInfo"]["hasNextPage"]:
+            break
+        cursor = items["pageInfo"]["endCursor"]
+    print(f"Read {total} items from project #{PROJECT_NUMBER}.")
+
+
+def scraper_slug(field_value):
+    """The morph.io scraper slug, or None if the field isn't a morph.io URL for this org.
+
+    A few items point at planningalerts.org.au instead, and some URLs have a trailing
+    slash.
+    """
+    if not field_value or not field_value.startswith(MORPH_PREFIX):
+        return None
+    return field_value[len(MORPH_PREFIX) :].strip("/") or None
+
+
+def candidates(token, config):
+    scraper_labels = config["scraper_labels"]
+    system_labels = set(config["system_labels"])
+    found = []
+    for number, labels, fields in project_items(token):
+        if not labels & system_labels:
+            label = scraper_labels.get(scraper_slug(fields.get("Scraper (Morph)")))
+            if label:
+                found.append((number, label, "system label from Scraper (Morph)"))
+        if fields.get("Status") == BUDGET_STATUS and BUDGET_LABEL not in labels:
+            found.append((number, BUDGET_LABEL, f"Status is {BUDGET_STATUS}"))
+    return found
+
+
+def previously_removed(token, numbers):
+    """{issue_number: {labels ever removed}} -- queried for candidates only."""
+    owner, name = REPO.split("/")
+    removed = {}
+    for number in sorted(numbers):
+        data = graphql(token, REMOVED_LABELS_QUERY, owner=owner, name=name, number=number)
+        events = data["repository"]["issue"]["timelineItems"]["nodes"]
+        removed[number] = {event["label"]["name"] for event in events}
+    return removed
+
+
+def add_label(token, number, label):
+    request(f"{API}/repos/{REPO}/issues/{number}/labels", token, {"labels": [label]})
+
+
+def summarise(lines):
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a") as handle:
+            handle.write("\n".join(lines) + "\n")
+
+
+def main():
+    dry_run = "--dry-run" in sys.argv[1:]
+    token = os.environ.get("GH_TOKEN")
+    if not token:
+        sys.exit("GH_TOKEN is not set.")
+
+    config = json.loads(CONFIG_PATH.read_text())
+    proposed = candidates(token, config)
+    removed = previously_removed(token, {number for number, _, _ in proposed})
+
+    applied, vetoed = [], []
+    for number, label, reason in proposed:
+        if label in removed[number]:
+            vetoed.append((number, label))
+            continue
+        if not dry_run:
+            add_label(token, number, label)
+        applied.append((number, label, reason))
+
+    verb = "Would add" if dry_run else "Added"
+    lines = [f"### {verb} {len(applied)} label(s)"]
+    lines += [f"- #{number} `{label}` -- {reason}" for number, label, reason in applied] or [
+        "- nothing to do"
+    ]
+    if vetoed:
+        lines.append("")
+        lines.append(f"Skipped {len(vetoed)} previously removed label(s):")
+        lines += [f"- #{number} `{label}`" for number, label in vetoed]
+
+    report = "\n".join(lines)
+    print(report)
+    summarise(lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/label-from-project.yml
+++ b/.github/workflows/label-from-project.yml
@@ -1,0 +1,59 @@
+name: Label issues from the project
+
+# Applies the labels that can be derived from the org project -- the system label implied
+# by `Scraper (Morph)`, and `ready awaiting budget` from the `Status` field. Add-only, and
+# it never re-applies a label that has been removed. See AGENTS.md.
+#
+# Reading an org-level project needs more than the built-in GITHUB_TOKEN, so this mints an
+# installation token for the planningalerts-bot GitHub App (App ID 4480419), which already
+# has Issues: write and Organization projects: read. `actions/create-github-app-token` is
+# GitHub-owned, so it satisfies this org's Actions allowlist.
+#
+# Required repository secrets:
+#   PLANNINGALERTS_BOT_APP_ID       -- 4480419
+#   PLANNINGALERTS_BOT_PRIVATE_KEY  -- a private key generated for that app
+#
+# Manual runs default to a dry run, so you can see what would change before it changes.
+
+on:
+  schedule:
+    # Runs daily. Scheduled workflows are disabled by GitHub after 60 days of repo
+    # inactivity, so workflow_dispatch is kept as a manual fallback.
+    - cron: "42 19 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report what would change without applying any labels"
+        type: boolean
+        default: true
+
+# Only what actions/checkout needs. Labels are written with the app token, not this one.
+permissions:
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Mint a planningalerts-bot token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.PLANNINGALERTS_BOT_APP_ID }}
+          private-key: ${{ secrets.PLANNINGALERTS_BOT_PRIVATE_KEY }}
+
+      - name: Apply labels derived from the project
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Scheduled runs apply for real; manual runs dry-run unless told otherwise.
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ "$DRY_RUN" = "true" ]; then
+            python3 .github/scripts/label_from_project.py --dry-run
+          else
+            python3 .github/scripts/label_from_project.py
+          fi

--- a/.github/workflows/label-reported.yml
+++ b/.github/workflows/label-reported.yml
@@ -1,0 +1,64 @@
+name: Label reported issues
+
+# Adds the `reported` label when someone links a Missive conversation on an issue.
+# See AGENTS.md for the convention: a comment beginning `Missive conversation:` means
+# somebody outside the team told us this authority was broken.
+#
+# Uses the gh CLI only (no third-party actions): this org's Actions policy allows only
+# GitHub-owned/verified actions, and the gh CLI is a preinstalled runner tool rather than
+# a marketplace action, so it isn't subject to that allowlist.
+#
+# The comment body is attacker-controlled -- this is a public repo and anyone can comment.
+# It is passed to the script via `env:` and never interpolated into the shell, and the
+# author must be a member/owner/collaborator before we act on it.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    # Skip pull request comments, and comments from outside the team.
+    if: >-
+      github.event.issue.pull_request == null &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add `reported` if this comment links a Missive conversation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          LABEL="reported"
+
+          # Strict prefix. `Missive conversation (email to council):`, `Email sent:` and
+          # similar are outbound correspondence and deliberately do not count.
+          if ! printf '%s' "$COMMENT_BODY" | grep -qE '^[[:space:]]*Missive conversation:'; then
+            echo "No \`Missive conversation:\` line in this comment, nothing to do."
+            exit 0
+          fi
+
+          if gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json labels \
+              --jq '.labels[].name' | grep -qxF "$LABEL"; then
+            echo "Issue #${ISSUE_NUMBER} already has \`${LABEL}\`."
+            exit 0
+          fi
+
+          # A removed label is a decision, not an absence: if someone has taken `reported`
+          # off this issue, don't put it back.
+          REMOVALS="$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/timeline" --paginate \
+            --jq "[.[] | select(.event == \"unlabeled\" and .label.name == \"${LABEL}\")] | length")"
+          if [ "$REMOVALS" != "0" ]; then
+            echo "\`${LABEL}\` was previously removed from issue #${ISSUE_NUMBER}, leaving it off."
+            exit 0
+          fi
+
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "$LABEL"
+          echo "Added \`${LABEL}\` to issue #${ISSUE_NUMBER}." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/label-reported.yml
+++ b/.github/workflows/label-reported.yml
@@ -53,9 +53,12 @@ jobs:
 
           # A removed label is a decision, not an absence: if someone has taken `reported`
           # off this issue, don't put it back.
-          REMOVALS="$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/timeline" --paginate \
-            --jq "[.[] | select(.event == \"unlabeled\" and .label.name == \"${LABEL}\")] | length")"
-          if [ "$REMOVALS" != "0" ]; then
+          #
+          # Grep the stream rather than count it: `--paginate` applies `--jq` per page and
+          # concatenates, so a count would come back as "0\n0" once the timeline exceeds
+          # one page, and the veto would fire on every busy issue.
+          if gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/timeline" --paginate \
+              --jq '.[] | select(.event == "unlabeled") | .label.name' | grep -qxF "$LABEL"; then
             echo "\`${LABEL}\` was previously removed from issue #${ISSUE_NUMBER}, leaving it off."
             exit 0
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,147 @@
+# AGENTS.md
+
+Guidance for agents working in `planningalerts-scrapers/issues`.
+
+## What this repo is
+
+This repo contains **no scraper code**. It is a tracker: one issue per PlanningAlerts
+authority that has stopped returning data, covering every scraper in the org.
+
+Issues are centralised here rather than kept in each scraper's own repo because
+authorities migrate between systems. When a council moves from, say, ePathway to
+Development.i, the fix spans two scraper repos plus a change to the PlanningAlerts
+authority record. A single issue can hold that whole story; three issues in three repos
+cannot.
+
+Issues are opened from the PlanningAlerts side and currently appear under `@mlandauer`.
+
+## Where the real data is
+
+Almost nothing useful lives in the issue body. The body is boilerplate. The context is in
+the org project, [PlanningAlerts authorities with no new data](https://github.com/orgs/planningalerts-scrapers/projects/3),
+and in the labels.
+
+Project fields worth reading:
+
+| Field | What it tells you |
+| --- | --- |
+| `Authority` | The council's name as PlanningAlerts knows it |
+| `Scraper (Morph)` | **The scraper currently pointed at this authority** — see below |
+| `Authority admin (PA)` | Direct link to the authority record in PlanningAlerts admin |
+| `Website` | The council's own site |
+| `No data received since` | When the data stopped |
+| `State`, `Population` | Jurisdiction and rough priority |
+| `Status` | Blocked / Todo / In Progress / Budget wait / Review / Done |
+
+Project fields are populated after the issue is created, so a freshly opened issue may
+briefly have none of them. A handful of older issues were never added to the project at
+all.
+
+## Finding the repo to work in
+
+`Scraper (Morph)` gives a morph.io URL. The code is the matching GitHub repo:
+
+```
+https://morph.io/planningalerts-scrapers/multiple_greenlight
+                                          └─────────┬────────┘
+https://github.com/planningalerts-scrapers/multiple_greenlight
+```
+
+A `multiple_*` slug is a **multi-authority scraper**: the authority is one entry in that
+repo's configuration, and adding or removing a council means editing that config, not
+writing new code. Any other slug is a **single-authority scraper** written just for that
+council.
+
+## The label leads, the Scraper field lags
+
+The system label (`epathway`, `greenlight`, `development-i`, …) records the system the
+authority **is on now**. The `Scraper (Morph)` field records the scraper **still pointed at
+it**. When an authority migrates, the label changes first and the field only changes once
+the work is done.
+
+So the two disagreeing is not an error — it is the signal that the authority has moved and
+the scraper needs to follow. **Never "correct" a label to match the `Scraper (Morph)`
+field.** Roughly one in ten open issues is in this state deliberately.
+
+## Worked example: [#1391 Gold Coast City Council](https://github.com/planningalerts-scrapers/issues/issues/1391)
+
+Read together, the tags and fields say what the job is:
+
+- `Scraper (Morph)` = `multiple_epathway_scraper` → the repo currently responsible, so
+  that is where the failure is showing up and where you look first.
+- Label `development-i` → the system Gold Coast has **moved to**. The destination repo is
+  therefore [`multiple_developmenti`](https://github.com/planningalerts-scrapers/multiple_developmenti).
+- Label `new authority for existing scraper` → extend an existing multi-scraper's config.
+  Do not write a new scraper.
+- Label `reported` → someone outside the team cared enough to report it, and there is a
+  `Missive conversation:` comment on the issue
+  ([example](https://github.com/planningalerts-scrapers/issues/issues/1391#issuecomment-5247828005)).
+- Project: QLD, population 625,087, no data since 2026-06-13, Status `Todo`, authority
+  record at `/admin/authorities/42`.
+
+Which resolves to work in **two** scraper repos — add Gold Coast to `multiple_developmenti`,
+remove the dead authority from `multiple_epathway_scraper` — plus repointing the
+PlanningAlerts authority record from one morph scraper to the other. Only then can the
+issue close.
+
+## Labels
+
+**System** — which platform the authority is on:
+`masterview`, `greenlight`, `epathway`, `icon`, `technology one`, `horizon`, `civica`,
+`nsw planning portal`, `ATDIS`, `development-i`, `ci-anywhere`, `html table`, `div_card`,
+`ePlanning`, `planbuild (tas)`, `granicus`, `elementorg`, `DxP T1`, `custom`
+
+**Cause** — why the data stopped:
+`anti scraping technology`, `cloudflare`, `blocked by ip`, `blocked by authority`,
+`does not publish`, `no da tracking site`, `site in flux`
+
+**Effort and state**:
+`quick fix`, `extended effort`, `stuck - need help`, `ready awaiting budget`,
+`new scraper needed`, `new authority for existing scraper`, `probably fixed`
+
+**Process**:
+`reported`, `waiting callback`, `compare data`, `research`, `council website good`,
+`council website bad`
+
+### The `reported` convention
+
+An issue gets `reported` when a comment beginning exactly `Missive conversation:` is added
+— someone outside the team told us this was broken, and that link is the thread.
+
+Outbound correspondence does **not** count. Comments like
+`Missive conversation (email to council):`, `Email sent:` or `Email to local council:` are
+us contacting them, not them reporting to us, and deliberately do not trigger the label.
+
+## Automation
+
+Two workflows keep the mechanical parts of the labelling current. Both are **add-only** and
+neither ever removes a label.
+
+| Workflow | Trigger | What it does |
+| --- | --- | --- |
+| `.github/workflows/label-reported.yml` | A comment is posted | Adds `reported` when the comment starts with `Missive conversation:` |
+| `.github/workflows/label-from-project.yml` | Daily, or manually | Adds the system label implied by `Scraper (Morph)`, and `ready awaiting budget` when Status is `Budget wait` |
+
+The slug-to-label mapping lives in `.github/scraper-labels.json`, so adding a new
+multi-scraper means editing that file, not the script.
+
+Three rules constrain both:
+
+1. **Never overwrite a system label.** If an issue already carries one, the scraper-derived
+   label is skipped. This is what protects the migration cases described above.
+2. **A removed label is permanent.** If a label has ever been taken off an issue, the
+   automation will not put it back. Removing a label is how you tell the bot to stop
+   applying it. The veto is per label, so removing `epathway` from an issue does not stop a
+   later, correct `greenlight` from being added.
+3. **Single-authority scrapers get no system label.** Whether a bespoke scraper counts as
+   `custom` is a judgement call, so the automation leaves it alone.
+
+## Conventions
+
+- Never remove a curated label to make it match the `Scraper (Morph)` field.
+- The default branch is `master`. Branch off it, and open pull requests against it. (The
+  org `CONTRIBUTING.md` says `main`; this repo predates that and has not been renamed.)
+- Follow the org [CONTRIBUTING.md](https://github.com/planningalerts-scrapers/.github/blob/main/CONTRIBUTING.md)
+  otherwise: branch names like `chore/123-short-description`, fill in the pull request
+  template, assign the pull request to yourself.
+- Every commit ends with `Assisted-by: Claude Code:<model-id>` in the trailer block.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ neither ever removes a label.
 | Workflow | Trigger | What it does |
 | --- | --- | --- |
 | `.github/workflows/label-reported.yml` | A comment is posted | Adds `reported` when the comment starts with `Missive conversation:` |
-| `.github/workflows/label-from-project.yml` | Daily, or manually | Adds the system label implied by `Scraper (Morph)`, and `ready awaiting budget` when Status is `Budget wait` |
+| `.github/workflows/label-from-project.yml` | Daily, or manually | Adds the system label implied by `Scraper (Morph)`, and `ready awaiting budget` when Status is `Budget wait` — **does nothing until the `planningalerts-bot` secrets described in the workflow are configured** |
 
 The slug-to-label mapping lives in `.github/scraper-labels.json`, so adding a new
 multi-scraper means editing that file, not the script.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Development.i, the fix spans two scraper repos plus a change to the PlanningAler
 authority record. A single issue can hold that whole story; three issues in three repos
 cannot.
 
-Issues are opened from the PlanningAlerts side and currently appear under `@mlandauer`.
+Issues are opened from the PlanningAlerts side and currently appear under `@mlandauer` (there is an open issue to change this to a service user).
 
 ## Where the real data is
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](AGENTS.md) for how this repo works.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-See [AGENTS.md](AGENTS.md) for how this repo works.
+@AGENTS.md


### PR DESCRIPTION
## Description

Two things: documentation for agents and people landing in this repo, and automation for the mechanical parts of the labelling.

**`AGENTS.md`** (plus a one-line `CLAUDE.md` pointing at it) explains what a reader can't discover from the repo, since there's no code here:

- the real context lives in [project #3](https://github.com/orgs/planningalerts-scrapers/projects/3), not the issue body
- `Scraper (Morph)` is what tells you which repo to work in, and a `multiple_*` slug means editing config rather than writing a scraper
- **the label leads, the `Scraper (Morph)` field lags** — a system label that disagrees with the scraper field is an authority mid-migration, not a mistake to correct
- #1391 Gold Coast written out longhand as a worked example, ending in work across two scraper repos plus repointing the PlanningAlerts authority record
- the label taxonomy grouped by what it's for, and the `Missive conversation:` convention behind `reported`

**Two workflows**, both add-only:

| Workflow | Trigger | What it does |
| --- | --- | --- |
| `label-reported.yml` | A comment is posted | Adds `reported` when the comment begins `Missive conversation:` |
| `label-from-project.yml` | Daily, or manually | Adds the system label implied by `Scraper (Morph)`, and `ready awaiting budget` when Status is `Budget wait` |

Three guards constrain both:

1. **Never overwrites a system label.** If an issue already has one, the scraper-derived label is skipped. This is what protects the ~14 open migration cases.
2. **A removed label is permanent.** If a label has ever been taken off an issue it's never re-applied — removing a label is how you tell the bot to stop. The veto is *per label*: #1394 had `epathway` removed by hand in July, and still correctly gets `greenlight`.
3. **Single-authority scrapers get no system label.** Whether a bespoke scraper is `custom` is a judgement call (only 2 of 6 `cardinia` issues carry it), so the automation leaves it alone.

The slug-to-label mapping is data in `.github/scraper-labels.json`, so adding a new multi-scraper doesn't mean touching the script.

`label-reported.yml` needs no secret and works as soon as this merges. `label-from-project.yml` needs the `planningalerts-bot` App (4480419) — see below.

### Setup still required

`label-from-project.yml` is inert until:

1. `planningalerts-bot` is confirmed installed on this repo (its installation is `repository_selection: selected`)
2. Repo secrets `PLANNINGALERTS_BOT_APP_ID` (`4480419`) and `PLANNINGALERTS_BOT_PRIVATE_KEY` exist

Reading an org-level project needs more than `GITHUB_TOKEN`, and that app already has exactly `Issues: write` + `Organization projects: read`.

## Motivation and Context

Nothing in the repo explained how to read an issue — a two-line README and 162 open issues, with no hint that a project field is what points at the code.

And the labelling had drifted: **24 open issues had no system label** despite their `Scraper (Morph)` field saying exactly which system they're on, and **4 had a `Missive conversation:` comment without `reported`**. Both are mechanical, both were being done by hand.

Deliberately out of scope: weaker signals like cloudflare/403 text in comments. The data shows those disagree with existing labels often enough that auto-applying them would overwrite human judgement.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

`label_from_project.py --dry-run` against the live project:

- reads 920 project items, proposes exactly the **24** expected system labels, **0** `ready awaiting budget` (all 7 `Budget wait` issues already have it)
- **#1391 correctly skipped** — it already carries `development-i`
- **#1394 correctly proposed** for `greenlight` despite its `epathway` removal, confirming the veto is per-label not per-issue

Unit-checked separately: trailing-slash normalisation (`multiple_cianywhere/`), rejection of the one non-morph.io URL in the data (a `planningalerts.org.au` link), and the removal-veto data for #1394/#841/#1421.

The `Missive conversation:` matcher was checked against every real comment form in the repo — it matches the 26 canonical ones and rejects `Missive conversation (email to council):`, `Email sent:`, `Email to local council:` and a `[Response](...)` link.

The four-issue backfill is already applied (#1213, #1084, #909, #841 → open `reported` went 12 to 16), and #1185 and #927 correctly stayed unlabelled.

Still to verify after merge, since they need the secrets and a live event: a `dry_run=true` workflow run, an apply-then-dry-run pair for idempotency, and a real `Missive conversation:` comment.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---

Drafted with Claude Code (claude-opus-5).
