### PR TITLE
Fix deprecation warnings in label workflow

### DIFF
--- a/.github/workflows/label-from-project.yml
+++ b/.github/workflows/label-from-project.yml
@@ -10,7 +10,8 @@ name: Label issues from the project
 # GitHub-owned, so it satisfies this org's Actions allowlist.
 #
 # Required repository secrets:
-#   PLANNINGALERTS_BOT_APP_ID       -- 4480419
+#   PLANNINGALERTS_BOT_APP_ID       -- 4480419 (passed to `client-id`, which accepts an
+#                                      App ID or a Client ID interchangeably)
 #   PLANNINGALERTS_BOT_PRIVATE_KEY  -- a private key generated for that app
 #
 # Manual runs default to a dry run, so you can see what would change before it changes.
@@ -36,13 +37,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Mint a planningalerts-bot token
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.PLANNINGALERTS_BOT_APP_ID }}
+          client-id: ${{ secrets.PLANNINGALERTS_BOT_APP_ID }}
           private-key: ${{ secrets.PLANNINGALERTS_BOT_PRIVATE_KEY }}
 
       - name: Apply labels derived from the project


### PR DESCRIPTION
## Description

Fixes the two kinds of warnings raised by [run 31968629929](https://github.com/planningalerts-scrapers/issues/actions/runs/31968629929) of the "Label issues from the project" workflow:

- **Node.js 20 deprecation**: `actions/checkout@v4` targets Node.js 20, which is deprecated on GitHub-hosted runners. Bumped to `actions/checkout@v7` (Node.js 24, current major).
- **Deprecated `app-id` input**: `actions/create-github-app-token@v3` deprecated `app-id` in favour of `client-id`. Renamed the input. No secret change is needed — the action treats the two values interchangeably (`main.js` reads `client-id || app-id`, and GitHub's JWT `iss` claim accepts either an App ID or a Client ID), so `PLANNINGALERTS_BOT_APP_ID` continues to work. The comment block in the workflow documents this.

## Motivation and Context

Every scheduled run of the workflow currently emits three deprecation annotations. Both deprecations have hard cut-offs coming (Node 20 actions will eventually fail; `app-id` will be removed in a future major of the token action), so fixing them now keeps the daily labelling job from breaking later.

## How Has This Been Tested?

- [x] YAML validated locally (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Verified against `actions/create-github-app-token` source that `client-id` accepts the existing App ID value
- [ ] Confirmed it passed the GitHub actions tests — a manual `workflow_dispatch` dry run after merge will confirm the warnings are gone

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.