### PR TITLE
Document scraper repo AGENTS.md stubs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,14 @@ nsw_office_of_liquor_gaming_and_racing#5):
   `bundle exec rubocop`. Stricter `.rubocop.yml` settings routinely surface autocorrectable
   offences in older scrapers.
 
+## Scraper repo stubs
+
+Every scraper repo carries a stub `AGENTS.md` (plus a `CLAUDE.md` importing it)
+that points agents back to this file. This file is the single source of truth
+for org-wide agent guidance — update it here, not in the scraper repos. The
+stubs deliberately contain no guidance of their own so agents always fetch the
+current version of this file.
+
 ## Conventions
 
 - Never remove a curated label to make it match the `Scraper (Morph)` field.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a "Scraper repo stubs" section to `AGENTS.md`, immediately after "Working on scraper pull requests", documenting that every scraper repo carries a stub `AGENTS.md` (plus a `CLAUDE.md` importing it) pointing back to this file, which remains the single source of truth for org-wide agent guidance.

## Motivation and Context

Stub `AGENTS.md`/`CLAUDE.md` files are being rolled out to every active scraper repo in the org via parallel PRs, each pointing back to this repo's `AGENTS.md`. This companion PR records that pattern here so agents (and humans) know to update guidance in this file only, never in the scraper repos.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system

Documentation-only change; rendered Markdown reviewed locally.

- [ ] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
